### PR TITLE
tb-keycast--update: Fix error when `this-command' is not symbol

### DIFF
--- a/tb-keycast.el
+++ b/tb-keycast.el
@@ -102,9 +102,7 @@ Force update of mode-line and by that udate tab-bar line."
                   (propertize (if (> tb-keycast--repeat 1)
                                   (format " x%s" tb-keycast--repeat) "")
                               'face 'tb-keycast-repeat-number-face)
-                  (propertize (if (symbolp this-command)
-                                  (symbol-name this-command)
-                                (format "%S" this-command))
+                  (propertize (format "%s" this-command))
                               'face 'tb-keycast-fun-name-face)))
 
     ;; Set min width to avoid constant jumps to right and left.

--- a/tb-keycast.el
+++ b/tb-keycast.el
@@ -102,7 +102,9 @@ Force update of mode-line and by that udate tab-bar line."
                   (propertize (if (> tb-keycast--repeat 1)
                                   (format " x%s" tb-keycast--repeat) "")
                               'face 'tb-keycast-repeat-number-face)
-                  (propertize (symbol-name this-command)
+                  (propertize (if (symbolp this-command)
+                                  (symbol-name this-command)
+                                (format "%S" this-command))
                               'face 'tb-keycast-fun-name-face)))
 
     ;; Set min width to avoid constant jumps to right and left.


### PR DESCRIPTION
Fixes #5 